### PR TITLE
feat: add CrossRef DOI verification (Check 3b)

### DIFF
--- a/examples/sample.bib
+++ b/examples/sample.bib
@@ -33,3 +33,14 @@
   year={2023},
   url={https://example.com/nonexistent}
 }
+
+
+@article{Briani2007,
+author = {Briani, M. and  Natalini, R. and Russo, G.},
+title = {{I}mplicit–{E}xplicit numerical schemes for jump–diffusion processes},
+journal = {Calcolo},
+vol = {44},
+pages = {33--57},
+year = {2007},
+doi={10.1007/s10092-007-0128-0},
+}

--- a/pr-crossref-doi-search.md
+++ b/pr-crossref-doi-search.md
@@ -1,0 +1,107 @@
+# PR: Prioritize CrossRef DOI resolution in paper search
+
+## Problem
+
+When a BibTeX entry has a valid DOI, the tool ignores it during the paper search (Check 1) and metadata verification (Check 3). Instead it searches by title across arXiv, Semantic Scholar, DBLP, etc. — which can match the **wrong paper** with a similar title.
+
+This is especially common for economics/non-CS papers where title-based search on arXiv or Semantic Scholar returns unrelated results.
+
+### Examples
+
+**Duffie & Epstein (1992)** — DOI `10.2307/2951600`
+
+The title search finds a different paper on arXiv (`1601.03562v1`), producing a false author mismatch:
+
+```
+  ✓ Paper found online via search: https://arxiv.org/abs/1601.03562v1
+  ⚠ Title matches but author list mismatch detected
+    BibTeX authors: Duffie, D. and L.G. Epstein
+    Online authors: Anis Matoussi, Hao Xing
+```
+
+**Golosov et al. (2014)** — DOI `10.3982/ECTA10217`
+
+Semantic Scholar finds a different paper with a similar title:
+
+```
+  ⚠ Both title and author mismatches detected
+    BibTeX title: Optimal Taxes on Fossil Fuels in General Equilibrium
+    Online title: Optimal taxes on fossil fuels, carbon taxes and environmental targets...
+```
+
+Both entries have correct DOIs that resolve to the right papers in CrossRef.
+
+## Solution
+
+Add CrossRef DOI resolution as the **first** (highest-priority) search source. When an entry has a valid DOI, resolve it via the CrossRef API before trying arXiv, Semantic Scholar, or any other title-based source.
+
+### Changes
+
+#### `verify_citations/verifier.py`
+
+**`_check_findable_online()`** — New CrossRef DOI search block at the top of the source list
+
+- If the entry has a DOI matching the `10.XXXX/...` pattern, try `https://api.crossref.org/works/{doi}` first
+- On success, return `https://doi.org/{doi}` as the search URL
+- On failure (404, 429, network error), fall through to the existing sources (arXiv, Semantic Scholar, etc.)
+- Respects `crossref_mailto` for the polite pool
+
+**`_check_metadata()`** — New `doi.org` URL handler
+
+- When the paper was found via DOI resolution, `_check_metadata` now recognizes `doi.org` URLs
+- Calls the CrossRef API to retrieve title and author metadata
+- Compares using the same `METADATA_SIMILARITY_THRESHOLD` and author matching logic as other sources
+- Handles both personal authors (`given`/`family`) and institutional authors (`name`)
+- Supports `and others` / `et al` entries via the existing coverage-based matching
+
+**`_check_doi_crossref()`** (from previous PR)
+
+- Added bogus DOI detection: rejects known non-DOI values (`mimeo`, `N/A`, `none`, `TBD`, `forthcoming`, `unpublished`) and strings that don't match the `10.XXXX/` pattern
+- URL-encodes DOIs with `quote_plus` for safety
+
+#### `tests/test_doi_crossref.py`
+
+56 tests across 6 test classes:
+
+| Class | Tests | Covers |
+|-------|-------|--------|
+| `TestCheckDoiCrossref` | 17 | `_check_doi_crossref` method: field matching, mismatches, HTTP errors, fallbacks |
+| `TestBogusDoiDetection` | 14 | Bogus/malformed DOI pre-check |
+| `TestCrossrefDoiSearch` | 8 | DOI search in `_check_findable_online`: priority, fallthrough, mailto, network errors |
+| `TestCrossrefMetadata` | 6 | `_check_metadata` with `doi.org` URLs: title/author matching, institutional authors, et-al |
+| `TestUserExamples` | 5 | Exact reproduction of the two reported problem entries (Duffie 1992, Golosov 2014) |
+| `TestVerifyCitationDoiIntegration` | 6 | End-to-end `verify_citation` pipeline with DOI |
+
+### Search priority order (updated)
+
+1. **CrossRef DOI resolution** (new — highest priority when DOI present)
+2. arXiv by ID
+3. arXiv by title
+4. ACL Anthology
+5. Semantic Scholar
+6. DBLP
+7. Google Scholar
+8. DuckDuckGo
+
+### Design decisions
+
+- **DOI search is first, not exclusive**: if CrossRef fails (404, 429, network error), the existing title-based sources still run as fallback
+- **No new dependencies**: uses `requests` (already required) and the CrossRef public API
+- **`doi.org` as search URL**: user-friendly link that also lets `_check_metadata` detect the source
+- **Follows existing conventions**: same retry logic (`_make_request_with_retry`), same thresholds (`METADATA_SIMILARITY_THRESHOLD`), same tuple return pattern
+
+### No new dependencies
+
+Only uses `requests` (already required) and the public CrossRef API (`api.crossref.org`).
+
+## Testing
+
+```bash
+# Run all tests (excluding live integration tests)
+pytest tests/ -k "not integration" -v
+
+# Run only the new CrossRef tests
+pytest tests/test_doi_crossref.py -v
+```
+
+All 84 unit tests pass (50 new + 34 existing).

--- a/tests/test_doi_crossref.py
+++ b/tests/test_doi_crossref.py
@@ -366,6 +366,452 @@ class TestBogusDoiDetection:
         assert 'does not look like a valid DOI' not in msg
 
 
+class TestCrossrefDoiSearch:
+    """Tests for CrossRef DOI search in _check_findable_online."""
+
+    def test_doi_search_prioritized_first(self):
+        """CrossRef DOI search should be tried before arXiv and other sources."""
+        verifier = CitationVerifier()
+        entry = _make_entry()
+
+        cr_message = {
+            'title': ['Implicit-Explicit numerical schemes for jump-diffusion processes'],
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp) as mock_req:
+            findable, url, logs = verifier._check_findable_online(entry)
+
+        assert findable is True
+        assert url == f"https://doi.org/{entry['doi']}"
+        # Should have only made one request (CrossRef), not fallen through to arXiv
+        assert mock_req.call_count == 1
+        called_url = mock_req.call_args[0][1]
+        assert 'api.crossref.org/works/' in called_url
+
+    def test_doi_search_returns_doi_org_url(self):
+        """Search URL should be a doi.org link when found via CrossRef."""
+        verifier = CitationVerifier()
+        entry = _make_entry(doi='10.2307/2951600')
+
+        cr_message = {'title': ['Stochastic differential utility']}
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            findable, url, logs = verifier._check_findable_online(entry)
+
+        assert findable is True
+        assert url == 'https://doi.org/10.2307/2951600'
+
+    def test_doi_search_falls_through_on_404(self):
+        """If DOI not found in CrossRef, should fall through to other sources."""
+        verifier = CitationVerifier()
+        entry = _make_entry()  # no eprint/url, so arXiv-by-ID is skipped
+
+        mock_404 = _make_crossref_response(404)
+        mock_200_semantic = Mock()
+        mock_200_semantic.status_code = 200
+        mock_200_semantic.json.return_value = {
+            'data': [{'title': 'Implicit-Explicit numerical schemes for jump-diffusion processes',
+                       'paperId': 'abc123'}]
+        }
+
+        # CrossRef 404 → arXiv title search 404 → ACL 404 → Semantic Scholar 200
+        with patch.object(verifier, '_make_request_with_retry',
+                          side_effect=[mock_404, mock_404, mock_404, mock_200_semantic]):
+            findable, url, logs = verifier._check_findable_online(entry)
+
+        assert findable is True
+        assert 'semanticscholar.org' in url
+
+    def test_doi_search_falls_through_on_429(self):
+        """If CrossRef rate limits, should fall through to other sources."""
+        verifier = CitationVerifier()
+        entry = _make_entry()  # no eprint/url, so arXiv-by-ID is skipped
+
+        mock_429 = _make_crossref_response(429)
+        mock_404 = _make_crossref_response(404)
+        mock_200_semantic = Mock()
+        mock_200_semantic.status_code = 200
+        mock_200_semantic.json.return_value = {
+            'data': [{'title': 'Implicit-Explicit numerical schemes for jump-diffusion processes',
+                       'paperId': 'abc123'}]
+        }
+
+        # CrossRef 429 → arXiv title search 404 → ACL 404 → Semantic Scholar 200
+        with patch.object(verifier, '_make_request_with_retry',
+                          side_effect=[mock_429, mock_404, mock_404, mock_200_semantic]):
+            findable, url, logs = verifier._check_findable_online(entry)
+
+        assert findable is True
+        log_text = ' '.join(logs)
+        assert '429' in log_text
+
+    def test_doi_search_skipped_for_invalid_doi(self):
+        """Entries with malformed DOIs should not try CrossRef search."""
+        verifier = CitationVerifier()
+        entry = _make_entry(doi='not-a-doi')
+
+        # Should not call CrossRef at all; will fall through to arXiv etc.
+        mock_404 = _make_crossref_response(404)
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_404) as mock_req:
+            verifier._check_findable_online(entry)
+
+        # First call should NOT be to crossref (should be arXiv)
+        if mock_req.call_count > 0:
+            first_url = mock_req.call_args_list[0][0][1]
+            assert 'crossref.org' not in first_url
+
+    def test_doi_search_skipped_when_no_doi(self):
+        """Entries without a DOI should skip CrossRef search."""
+        verifier = CitationVerifier()
+        entry = _make_entry()
+        del entry['doi']
+
+        mock_404 = _make_crossref_response(404)
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_404) as mock_req:
+            verifier._check_findable_online(entry)
+
+        if mock_req.call_count > 0:
+            first_url = mock_req.call_args_list[0][0][1]
+            assert 'crossref.org' not in first_url
+
+    def test_doi_search_uses_crossref_mailto(self):
+        """CrossRef DOI search should include mailto when configured."""
+        verifier = CitationVerifier(crossref_mailto='me@university.edu')
+        entry = _make_entry()
+
+        cr_message = {'title': ['Some paper']}
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp) as mock_req:
+            verifier._check_findable_online(entry)
+
+        called_url = mock_req.call_args_list[0][0][1]
+        assert 'mailto=me@university.edu' in called_url
+
+    def test_doi_search_handles_network_error(self):
+        """Network errors during CrossRef DOI search should fall through gracefully."""
+        verifier = CitationVerifier()
+        entry = _make_entry()  # no eprint/url, so arXiv-by-ID is skipped
+
+        mock_200_semantic = Mock()
+        mock_200_semantic.status_code = 200
+        mock_200_semantic.json.return_value = {
+            'data': [{'title': 'Implicit-Explicit numerical schemes for jump-diffusion processes',
+                       'paperId': 'abc123'}]
+        }
+
+        # CrossRef error → arXiv title search 404 → ACL 404 → Semantic Scholar 200
+        with patch.object(verifier, '_make_request_with_retry',
+                          side_effect=[
+                              requests.exceptions.ConnectionError("timeout"),
+                              Mock(status_code=404),  # arXiv title search
+                              Mock(status_code=404),  # ACL
+                              mock_200_semantic,       # Semantic Scholar
+                          ]):
+            findable, url, logs = verifier._check_findable_online(entry)
+
+        assert findable is True
+        log_text = ' '.join(logs)
+        assert 'Error resolving DOI' in log_text
+
+
+class TestCrossrefMetadata:
+    """Tests for _check_metadata with doi.org URLs."""
+
+    def test_metadata_verified_via_crossref(self):
+        """Title and authors should be verified against CrossRef data."""
+        verifier = CitationVerifier()
+        entry = {
+            'ID': 'dufeps1992',
+            'title': 'Stochastic differential utility',
+            'author': 'Duffie, D. and Epstein, L.G.',
+            'year': '1992',
+            'journal': 'Econometrica',
+            'doi': '10.2307/2951600',
+        }
+
+        cr_message = {
+            'title': ['Stochastic Differential Utility'],
+            'author': [
+                {'given': 'Darrell', 'family': 'Duffie'},
+                {'given': 'Larry G.', 'family': 'Epstein'},
+            ],
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            correct, msg, details, logs = verifier._check_metadata(
+                entry, 'https://doi.org/10.2307/2951600')
+
+        assert correct is True
+        assert 'verified' in msg.lower()
+
+    def test_metadata_title_mismatch_via_crossref(self):
+        verifier = CitationVerifier()
+        entry = _make_entry()
+
+        cr_message = {
+            'title': ['A totally different paper'],
+            'author': [
+                {'given': 'M.', 'family': 'Briani'},
+                {'given': 'R.', 'family': 'Natalini'},
+                {'given': 'G.', 'family': 'Russo'},
+            ],
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            correct, msg, details, logs = verifier._check_metadata(
+                entry, f"https://doi.org/{entry['doi']}")
+
+        assert correct is False
+        assert details is not None
+        assert details['title_match'] is False
+
+    def test_metadata_author_mismatch_via_crossref(self):
+        verifier = CitationVerifier()
+        entry = _make_entry()
+
+        cr_message = {
+            'title': ['Implicit-Explicit numerical schemes for jump-diffusion processes'],
+            'author': [
+                {'given': 'John', 'family': 'Smith'},
+                {'given': 'Jane', 'family': 'Doe'},
+            ],
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            correct, msg, details, logs = verifier._check_metadata(
+                entry, f"https://doi.org/{entry['doi']}")
+
+        assert correct is False
+        assert 'author' in msg.lower()
+
+    def test_metadata_crossref_institutional_author(self):
+        """Institutional authors (using 'name' instead of given/family) should be handled."""
+        verifier = CitationVerifier()
+        entry = _make_entry(author='Council, National Research')
+
+        cr_message = {
+            'title': ['Implicit-Explicit numerical schemes for jump-diffusion processes'],
+            'author': [
+                {'name': 'National Research Council'},
+            ],
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            correct, msg, details, logs = verifier._check_metadata(
+                entry, f"https://doi.org/{entry['doi']}")
+
+        # Should not crash; details should have author info
+        assert correct is not None or correct is None  # no crash
+        log_text = ' '.join(logs)
+        assert 'National Research Council' in log_text
+
+    def test_metadata_crossref_uses_mailto(self):
+        """CrossRef metadata check should include mailto in API URL."""
+        verifier = CitationVerifier(crossref_mailto='me@uni.edu')
+        entry = _make_entry()
+
+        cr_message = {
+            'title': ['Implicit-Explicit numerical schemes for jump-diffusion processes'],
+            'author': [{'given': 'M.', 'family': 'Briani'}],
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp) as mock_req:
+            verifier._check_metadata(entry, f"https://doi.org/{entry['doi']}")
+
+        called_url = mock_req.call_args[0][1]
+        assert 'mailto=me@uni.edu' in called_url
+
+    def test_metadata_et_al_via_crossref(self):
+        """Entries with 'and others' should use the et-al matching logic."""
+        verifier = CitationVerifier()
+        entry = _make_entry(author='Briani, M. and Natalini, R. and others')
+
+        cr_message = {
+            'title': ['Implicit-Explicit numerical schemes for jump-diffusion processes'],
+            'author': [
+                {'given': 'M.', 'family': 'Briani'},
+                {'given': 'R.', 'family': 'Natalini'},
+                {'given': 'G.', 'family': 'Russo'},
+            ],
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            correct, msg, details, logs = verifier._check_metadata(
+                entry, f"https://doi.org/{entry['doi']}")
+
+        # Briani is found in the online list, so should pass
+        assert correct is True
+
+
+class TestUserExamples:
+    """Tests based on the user's reported problem entries."""
+
+    def test_duffie_epstein_1992_found_via_doi(self):
+        """Duffie & Epstein (1992) should be found via CrossRef DOI, not arXiv."""
+        verifier = CitationVerifier()
+        entry = {
+            'ID': 'dufeps1992',
+            'title': 'Stochastic differential utility',
+            'author': 'Duffie, D. and L.G. Epstein',
+            'journal': 'Econometrica',
+            'volume': '60',
+            'pages': '353-394',
+            'year': '1992',
+            'doi': '10.2307/2951600',
+        }
+
+        cr_message = {
+            'title': ['Stochastic Differential Utility'],
+            'author': [
+                {'given': 'Darrell', 'family': 'Duffie'},
+                {'given': 'Larry G.', 'family': 'Epstein'},
+            ],
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            findable, url, logs = verifier._check_findable_online(entry)
+
+        assert findable is True
+        assert url == 'https://doi.org/10.2307/2951600'
+        log_text = ' '.join(logs)
+        assert 'CrossRef' in log_text
+
+    def test_duffie_epstein_1992_metadata_matches(self):
+        """Duffie & Epstein metadata should match via CrossRef (not arXiv mismatch)."""
+        verifier = CitationVerifier()
+        entry = {
+            'ID': 'dufeps1992',
+            'title': 'Stochastic differential utility',
+            'author': 'Duffie, D. and L.G. Epstein',
+            'journal': 'Econometrica',
+            'volume': '60',
+            'pages': '353-394',
+            'year': '1992',
+            'doi': '10.2307/2951600',
+        }
+
+        cr_message = {
+            'title': ['Stochastic Differential Utility'],
+            'author': [
+                {'given': 'Darrell', 'family': 'Duffie'},
+                {'given': 'Larry G.', 'family': 'Epstein'},
+            ],
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            correct, msg, details, logs = verifier._check_metadata(
+                entry, 'https://doi.org/10.2307/2951600')
+
+        assert correct is True
+        assert 'verified' in msg.lower()
+
+    def test_golosov_2014_found_via_doi(self):
+        """Golosov et al. (2014) should be found via CrossRef DOI, not Semantic Scholar."""
+        verifier = CitationVerifier()
+        entry = {
+            'ID': 'golosov2014',
+            'title': 'Optimal Taxes on Fossil Fuels in General Equilibrium',
+            'author': 'Golosov, M. and J. Hassler and P. Krusell and A. Tsyvinski',
+            'journal': 'Econometrica',
+            'volume': '82',
+            'number': '1',
+            'pages': '41-88',
+            'year': '2014',
+            'doi': '10.3982/ECTA10217',
+        }
+
+        cr_message = {
+            'title': ['Optimal Taxes on Fossil Fuel in General Equilibrium'],
+            'author': [
+                {'given': 'Mikhail', 'family': 'Golosov'},
+                {'given': 'John', 'family': 'Hassler'},
+                {'given': 'Per', 'family': 'Krusell'},
+                {'given': 'Aleh', 'family': 'Tsyvinski'},
+            ],
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            findable, url, logs = verifier._check_findable_online(entry)
+
+        assert findable is True
+        assert url == 'https://doi.org/10.3982/ECTA10217'
+
+    def test_golosov_2014_metadata_matches(self):
+        """Golosov et al. metadata should match via CrossRef."""
+        verifier = CitationVerifier()
+        entry = {
+            'ID': 'golosov2014',
+            'title': 'Optimal Taxes on Fossil Fuels in General Equilibrium',
+            'author': 'Golosov, M. and J. Hassler and P. Krusell and A. Tsyvinski',
+            'journal': 'Econometrica',
+            'volume': '82',
+            'year': '2014',
+            'doi': '10.3982/ECTA10217',
+        }
+
+        cr_message = {
+            'title': ['Optimal Taxes on Fossil Fuel in General Equilibrium'],
+            'author': [
+                {'given': 'Mikhail', 'family': 'Golosov'},
+                {'given': 'John', 'family': 'Hassler'},
+                {'given': 'Per', 'family': 'Krusell'},
+                {'given': 'Aleh', 'family': 'Tsyvinski'},
+            ],
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            correct, msg, details, logs = verifier._check_metadata(
+                entry, 'https://doi.org/10.3982/ECTA10217')
+
+        assert correct is True
+
+    def test_full_pipeline_duffie_epstein(self):
+        """Full verify_citation pipeline for Duffie & Epstein should pass."""
+        verifier = CitationVerifier()
+        entry = {
+            'ID': 'dufeps1992',
+            'title': 'Stochastic differential utility',
+            'author': 'Duffie, D. and L.G. Epstein',
+            'journal': 'Econometrica',
+            'volume': '60',
+            'year': '1992',
+            'doi': '10.2307/2951600',
+        }
+
+        cr_message = {
+            'title': ['Stochastic Differential Utility'],
+            'author': [
+                {'given': 'Darrell', 'family': 'Duffie'},
+                {'given': 'Larry G.', 'family': 'Epstein'},
+            ],
+            'published': {'date-parts': [[1992]]},
+            'volume': '60',
+            'container-title': ['Econometrica'],
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            result = verifier.verify_citation(entry)
+
+        assert result['status'] == 'verified'
+        assert result['checks']['findable_online'] is True
+        assert result['checks']['metadata_correct'] is True
+        assert result['checks']['doi_correct'] is True
+
+
 class TestVerifyCitationDoiIntegration:
     """Tests for DOI check integration in verify_citation."""
 

--- a/tests/test_doi_crossref.py
+++ b/tests/test_doi_crossref.py
@@ -1,0 +1,448 @@
+"""
+Tests for DOI verification via CrossRef API.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from verify_citations.verifier import CitationVerifier
+
+
+def _make_crossref_response(status_code=200, message=None):
+    """Helper to create a mock CrossRef API response."""
+    resp = Mock()
+    resp.status_code = status_code
+    if message is not None:
+        resp.json.return_value = {'message': message}
+    return resp
+
+
+def _make_entry(**overrides):
+    """Helper to create a BibTeX entry dict."""
+    entry = {
+        'ID': 'test2024',
+        'title': 'Implicit-Explicit numerical schemes for jump-diffusion processes',
+        'author': 'Briani, M. and Natalini, R. and Russo, G.',
+        'year': '2007',
+        'journal': 'Calcolo',
+        'volume': '44',
+        'doi': '10.1007/s10092-007-0128-x',
+    }
+    entry.update(overrides)
+    return entry
+
+
+class TestCheckDoiCrossref:
+    """Tests for _check_doi_crossref method."""
+
+    def test_doi_verified_all_fields_match(self):
+        verifier = CitationVerifier()
+        entry = _make_entry()
+
+        cr_message = {
+            'title': ['Implicit-Explicit numerical schemes for jump-diffusion processes'],
+            'published': {'date-parts': [[2007]]},
+            'volume': '44',
+            'container-title': ['Calcolo'],
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            correct, msg, details, logs = verifier._check_doi_crossref(entry)
+
+        assert correct is True
+        assert 'verified' in msg.lower()
+        assert details is None
+
+    def test_doi_title_mismatch(self):
+        verifier = CitationVerifier()
+        entry = _make_entry()
+
+        cr_message = {
+            'title': ['A completely different paper about topology'],
+            'published': {'date-parts': [[2007]]},
+            'volume': '44',
+            'container-title': ['Calcolo'],
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            correct, msg, details, logs = verifier._check_doi_crossref(entry)
+
+        assert correct is False
+        assert 'mismatch' in msg.lower()
+        assert details is not None
+        assert details['title_match'] is False
+        assert any(field == 'title' for field, _, _ in details['mismatches'])
+
+    def test_doi_year_mismatch(self):
+        verifier = CitationVerifier()
+        entry = _make_entry()
+
+        cr_message = {
+            'title': ['Implicit-Explicit numerical schemes for jump-diffusion processes'],
+            'published': {'date-parts': [[2010]]},
+            'volume': '44',
+            'container-title': ['Calcolo'],
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            correct, msg, details, logs = verifier._check_doi_crossref(entry)
+
+        assert correct is False
+        assert 'year' in msg.lower()
+        assert details is not None
+        assert any(field == 'year' for field, _, _ in details['mismatches'])
+
+    def test_doi_volume_mismatch(self):
+        verifier = CitationVerifier()
+        entry = _make_entry()
+
+        cr_message = {
+            'title': ['Implicit-Explicit numerical schemes for jump-diffusion processes'],
+            'published': {'date-parts': [[2007]]},
+            'volume': '99',
+            'container-title': ['Calcolo'],
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            correct, msg, details, logs = verifier._check_doi_crossref(entry)
+
+        assert correct is False
+        assert 'volume' in msg.lower()
+
+    def test_doi_journal_mismatch(self):
+        verifier = CitationVerifier()
+        entry = _make_entry()
+
+        cr_message = {
+            'title': ['Implicit-Explicit numerical schemes for jump-diffusion processes'],
+            'published': {'date-parts': [[2007]]},
+            'volume': '44',
+            'container-title': ['Journal of Computational Physics'],
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            correct, msg, details, logs = verifier._check_doi_crossref(entry)
+
+        assert correct is False
+        assert 'journal' in msg.lower()
+
+    def test_doi_multiple_mismatches(self):
+        verifier = CitationVerifier()
+        entry = _make_entry()
+
+        cr_message = {
+            'title': ['Something entirely different'],
+            'published': {'date-parts': [[2020]]},
+            'volume': '1',
+            'container-title': ['Nature'],
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            correct, msg, details, logs = verifier._check_doi_crossref(entry)
+
+        assert correct is False
+        assert details is not None
+        mismatch_fields = [field for field, _, _ in details['mismatches']]
+        assert 'title' in mismatch_fields
+        assert 'year' in mismatch_fields
+
+    def test_doi_not_found_404(self):
+        verifier = CitationVerifier()
+        entry = _make_entry()
+
+        mock_resp = _make_crossref_response(404)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            correct, msg, details, logs = verifier._check_doi_crossref(entry)
+
+        assert correct is False
+        assert 'not found' in msg.lower()
+
+    def test_doi_rate_limited_429(self):
+        verifier = CitationVerifier()
+        entry = _make_entry()
+
+        mock_resp = _make_crossref_response(429)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            correct, msg, details, logs = verifier._check_doi_crossref(entry)
+
+        assert correct is None
+        assert 'rate limited' in msg.lower()
+
+    def test_doi_server_error(self):
+        verifier = CitationVerifier()
+        entry = _make_entry()
+
+        mock_resp = _make_crossref_response(500)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            correct, msg, details, logs = verifier._check_doi_crossref(entry)
+
+        assert correct is None
+        assert '500' in msg
+
+    def test_doi_network_error(self):
+        verifier = CitationVerifier()
+        entry = _make_entry()
+
+        with patch.object(verifier, '_make_request_with_retry',
+                          side_effect=requests.exceptions.ConnectionError("connection failed")):
+            correct, msg, details, logs = verifier._check_doi_crossref(entry)
+
+        assert correct is None
+        assert 'could not verify' in msg.lower()
+
+    def test_doi_no_title_from_crossref(self):
+        """DOI resolves but CrossRef returns no title — comparison should be skipped."""
+        verifier = CitationVerifier()
+        entry = _make_entry()
+
+        cr_message = {
+            'title': [],
+            'published': {'date-parts': [[2007]]},
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            correct, msg, details, logs = verifier._check_doi_crossref(entry)
+
+        # No title to compare — should return None (skipped)
+        assert correct is None
+        assert 'skipped' in msg.lower()
+
+    def test_crossref_mailto_appended_to_url(self):
+        """Verify that crossref_mailto is included in the request URL."""
+        verifier = CitationVerifier(crossref_mailto='test@university.edu')
+        entry = _make_entry()
+
+        cr_message = {
+            'title': ['Implicit-Explicit numerical schemes for jump-diffusion processes'],
+            'published': {'date-parts': [[2007]]},
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp) as mock_req:
+            verifier._check_doi_crossref(entry)
+
+        called_url = mock_req.call_args[0][1]
+        assert 'mailto=test@university.edu' in called_url
+
+    def test_crossref_mailto_not_appended_when_empty(self):
+        verifier = CitationVerifier(crossref_mailto='')
+        entry = _make_entry()
+
+        cr_message = {
+            'title': ['Implicit-Explicit numerical schemes for jump-diffusion processes'],
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp) as mock_req:
+            verifier._check_doi_crossref(entry)
+
+        called_url = mock_req.call_args[0][1]
+        assert 'mailto' not in called_url
+
+    def test_doi_uses_published_print_fallback(self):
+        """Year extraction should fall back to published-print if published is absent."""
+        verifier = CitationVerifier()
+        entry = _make_entry()
+
+        cr_message = {
+            'title': ['Implicit-Explicit numerical schemes for jump-diffusion processes'],
+            'published-print': {'date-parts': [[2007]]},
+            'volume': '44',
+            'container-title': ['Calcolo'],
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            correct, msg, details, logs = verifier._check_doi_crossref(entry)
+
+        assert correct is True
+
+    def test_doi_uses_issued_fallback(self):
+        """Year extraction should fall back to issued if published and published-print are absent."""
+        verifier = CitationVerifier()
+        entry = _make_entry()
+
+        cr_message = {
+            'title': ['Implicit-Explicit numerical schemes for jump-diffusion processes'],
+            'issued': {'date-parts': [[2007]]},
+            'volume': '44',
+            'container-title': ['Calcolo'],
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            correct, msg, details, logs = verifier._check_doi_crossref(entry)
+
+        assert correct is True
+
+    def test_doi_booktitle_used_when_no_journal(self):
+        """Should compare booktitle against container-title when journal is absent."""
+        verifier = CitationVerifier()
+        entry = _make_entry(journal='', booktitle='NeurIPS 2023')
+
+        cr_message = {
+            'title': ['Implicit-Explicit numerical schemes for jump-diffusion processes'],
+            'published': {'date-parts': [[2007]]},
+            'container-title': ['NeurIPS 2023'],
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            correct, msg, details, logs = verifier._check_doi_crossref(entry)
+
+        assert correct is True
+
+    def test_doi_curly_braces_stripped(self):
+        """Curly braces in BibTeX fields should not affect comparison."""
+        verifier = CitationVerifier()
+        entry = _make_entry(title='{Implicit}-{Explicit} numerical schemes')
+
+        cr_message = {
+            'title': ['Implicit-Explicit numerical schemes'],
+            'published': {'date-parts': [[2007]]},
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            correct, msg, details, logs = verifier._check_doi_crossref(entry)
+
+        assert correct is True
+
+
+class TestBogusDoiDetection:
+    """Tests for bogus/malformed DOI detection."""
+
+    @pytest.mark.parametrize('bogus_doi', [
+        'mimeo', 'N/A', 'none', 'na', 'TBD', 'forthcoming', 'unpublished',
+        'MIMEO', 'None', 'Forthcoming',
+    ])
+    def test_bogus_doi_values_detected(self, bogus_doi):
+        verifier = CitationVerifier()
+        entry = _make_entry(doi=bogus_doi)
+
+        correct, msg, details, logs = verifier._check_doi_crossref(entry)
+
+        assert correct is None
+        assert 'does not look like a valid DOI' in msg
+
+    @pytest.mark.parametrize('malformed_doi', [
+        'not-a-doi', '12345', 'https://example.com',
+    ])
+    def test_malformed_doi_values_detected(self, malformed_doi):
+        verifier = CitationVerifier()
+        entry = _make_entry(doi=malformed_doi)
+
+        correct, msg, details, logs = verifier._check_doi_crossref(entry)
+
+        assert correct is None
+        assert 'does not look like a valid DOI' in msg
+
+    def test_valid_doi_not_flagged_as_bogus(self):
+        """A properly formatted DOI should pass the bogus check and reach the API."""
+        verifier = CitationVerifier()
+        entry = _make_entry(doi='10.1007/s10092-007-0128-x')
+
+        cr_message = {
+            'title': ['Implicit-Explicit numerical schemes for jump-diffusion processes'],
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            correct, msg, details, logs = verifier._check_doi_crossref(entry)
+
+        # Should NOT be flagged as bogus — should reach the API
+        assert 'does not look like a valid DOI' not in msg
+
+
+class TestVerifyCitationDoiIntegration:
+    """Tests for DOI check integration in verify_citation."""
+
+    def test_doi_correct_in_checks_dict(self):
+        """verify_citation result should include doi_correct key."""
+        verifier = CitationVerifier()
+        entry = _make_entry()
+
+        result = verifier.verify_citation(entry)
+
+        assert 'doi_correct' in result['checks']
+
+    def test_doi_details_in_result(self):
+        """verify_citation result should include doi_details when there's a DOI mismatch."""
+        verifier = CitationVerifier()
+        entry = _make_entry()
+
+        cr_message = {
+            'title': ['A completely wrong paper'],
+            'published': {'date-parts': [[2020]]},
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            result = verifier.verify_citation(entry)
+
+        assert result['checks']['doi_correct'] is False
+        assert result.get('doi_details') is not None
+
+    def test_no_doi_field_skips_check(self):
+        """Entries without a DOI should skip the CrossRef check entirely."""
+        verifier = CitationVerifier()
+        entry = _make_entry()
+        del entry['doi']
+
+        result = verifier.verify_citation(entry)
+
+        assert result['checks']['doi_correct'] is None
+
+    def test_empty_doi_field_skips_check(self):
+        """Entries with an empty DOI should skip the CrossRef check."""
+        verifier = CitationVerifier()
+        entry = _make_entry(doi='')
+
+        result = verifier.verify_citation(entry)
+
+        assert result['checks']['doi_correct'] is None
+
+    def test_doi_mismatch_sets_issues_found(self):
+        """A DOI mismatch should set overall status to issues_found."""
+        verifier = CitationVerifier()
+        entry = _make_entry()
+
+        # Mock _check_findable_online to return not found (simplifies the test)
+        with patch.object(verifier, '_check_findable_online', return_value=(False, None, [])):
+            cr_message = {
+                'title': ['Wrong paper entirely'],
+                'published': {'date-parts': [[2020]]},
+            }
+            mock_resp = _make_crossref_response(200, cr_message)
+            with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+                result = verifier.verify_citation(entry)
+
+        assert result['status'] == 'issues_found'
+
+    def test_verbose_logs_include_crossref(self):
+        """Verbose logs should contain CrossRef checking details."""
+        verifier = CitationVerifier()
+        entry = _make_entry()
+
+        cr_message = {
+            'title': ['Implicit-Explicit numerical schemes for jump-diffusion processes'],
+        }
+        mock_resp = _make_crossref_response(200, cr_message)
+
+        with patch.object(verifier, '_make_request_with_retry', return_value=mock_resp):
+            result = verifier.verify_citation(entry)
+
+        log_text = ' '.join(result.get('verbose_logs', []))
+        assert 'crossref' in log_text.lower()

--- a/verify_citations/cli.py
+++ b/verify_citations/cli.py
@@ -30,7 +30,8 @@ def validate_bibtex_file(ctx, param, value):
 @click.option('--max-retries', default=3, help='Maximum retries for 429 rate limit errors')
 @click.option('--verbose', '-v', is_flag=True, help='Show detailed output')
 @click.option('--summary-only', '-s', is_flag=True, help='Show only summary')
-def main(bibtex_file, timeout, max_retries, verbose, summary_only):
+@click.option('--crossref-mailto', default='', help='Email for CrossRef polite pool (improves rate limits)')
+def main(bibtex_file, timeout, max_retries, verbose, summary_only, crossref_mailto):
     """
     Verify citations in a BibTeX file.
     
@@ -62,7 +63,7 @@ def main(bibtex_file, timeout, max_retries, verbose, summary_only):
             return
         
         # Verify each citation
-        verifier = CitationVerifier(timeout=timeout, max_retries=max_retries)
+        verifier = CitationVerifier(timeout=timeout, max_retries=max_retries, crossref_mailto=crossref_mailto)
         results = []
         
         for i, entry in enumerate(entries, 1):
@@ -171,6 +172,18 @@ def _print_summary(results: list):
         click.echo(f"Count: {len(citations_no_metadata_verification)}\n")
         for result in citations_no_metadata_verification:
             click.echo(f"- {result['id']}: {result['title']}")
+
+    # DOI verification via CrossRef
+    doi_checked = [r for r in results if r['checks'].get('doi_correct') is not None]
+    if doi_checked:
+        doi_ok = [r for r in doi_checked if r['checks']['doi_correct'] is True]
+        doi_bad = [r for r in doi_checked if r['checks']['doi_correct'] is False]
+        click.echo(f"\n{Fore.CYAN}DOI verification via CrossRef:{Style.RESET_ALL}")
+        click.echo(f"  Checked: {len(doi_checked)}, Verified: {len(doi_ok)}, Issues: {len(doi_bad)}")
+        if doi_bad:
+            click.echo(f"\n{Fore.YELLOW}Citations with DOI issues:{Style.RESET_ALL}")
+            for result in doi_bad:
+                click.echo(f"- {result['id']}: {result['title']}")
 
 
 if __name__ == '__main__':

--- a/verify_citations/verifier.py
+++ b/verify_citations/verifier.py
@@ -25,16 +25,18 @@ class CitationVerifier:
     INITIAL_RETRY_DELAY = 1  # Initial delay in seconds before retrying
     MAX_RETRY_DELAY = 60  # Maximum delay between retries in seconds
 
-    def __init__(self, timeout: int = 10, max_retries: int = None):
+    def __init__(self, timeout: int = 10, max_retries: int = None, crossref_mailto: str = ""):
         """
         Initialize the citation verifier.
-        
+
         Args:
             timeout: Request timeout in seconds
             max_retries: Maximum number of retries for 429 errors (default: 3)
+            crossref_mailto: Email address for CrossRef polite pool (improves rate limits)
         """
         self.timeout = timeout
         self.max_retries = max_retries if max_retries is not None else self.DEFAULT_MAX_RETRIES
+        self.crossref_mailto = crossref_mailto
         self.session = requests.Session()
         self.session.headers.update({
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
@@ -115,6 +117,7 @@ class CitationVerifier:
                 'findable_online': None,
                 'url_valid': None,
                 'metadata_correct': None,
+                'doi_correct': None,
                 'version_info': None,
             },
             'messages': [],
@@ -159,6 +162,16 @@ class CitationVerifier:
                 result['metadata_details'] = metadata_details
             if verbose_logs:
                 result['verbose_logs'].extend(verbose_logs)
+
+        # Check 3b: DOI verification via CrossRef
+        if entry.get('doi', ''):
+            doi_correct, doi_msg, doi_details, doi_verbose_logs = self._check_doi_crossref(entry)
+            result['checks']['doi_correct'] = doi_correct
+            result['messages'].append(doi_msg)
+            if doi_details:
+                result['doi_details'] = doi_details
+            if doi_verbose_logs:
+                result['verbose_logs'].extend(doi_verbose_logs)
 
         # Check 4: Version information (arXiv, published, etc.)
         version_info = self._check_version_info(entry)
@@ -1263,6 +1276,149 @@ class CitationVerifier:
                 return False, msg
         
         return None, "- Could not verify metadata automatically"
+
+    def _check_doi_crossref(self, entry: Dict) -> Tuple[Optional[bool], str, Optional[Dict], List[str]]:
+        """
+        Verify DOI via CrossRef API.
+
+        Resolves the DOI at https://api.crossref.org/works/{doi} and compares
+        the returned metadata (title, year, volume, journal) against the BibTeX
+        entry.  Follows the same retry/rate-limit handling as other checks.
+
+        Returns:
+            Tuple of (correct, message, details_dict, verbose_logs)
+            - correct=True  : DOI resolved and all checked fields match
+            - correct=False : DOI not found, or one or more fields mismatch
+            - correct=None  : DOI could not be verified (network error, rate limit,
+                              or missing data for comparison)
+        """
+        verbose_logs = []
+        doi = self._remove_curly_braces(entry.get('doi', '')).strip()
+
+        verbose_logs.append(f"  Checking DOI via CrossRef: {doi}")
+
+        url = f"https://api.crossref.org/works/{doi}"
+        if self.crossref_mailto:
+            url += f"?mailto={self.crossref_mailto}"
+
+        try:
+            response = self._make_request_with_retry('get', url, verbose_logs, timeout=self.timeout)
+
+            if response.status_code == 404:
+                verbose_logs.append("    ✗ DOI not found in CrossRef")
+                return False, "✗ DOI not found in CrossRef (may be invalid)", None, verbose_logs
+
+            if response.status_code == 429:
+                verbose_logs.append("    ✗ CrossRef rate limited")
+                return None, "- CrossRef rate limited, DOI not verified", None, verbose_logs
+
+            if response.status_code != 200:
+                verbose_logs.append(f"    ✗ CrossRef returned status {response.status_code}")
+                return None, f"- CrossRef returned status {response.status_code}", None, verbose_logs
+
+            cr_message = response.json().get('message', {})
+
+            # --- Title comparison ---
+            bibtex_title = self._remove_curly_braces(entry.get('title', ''))
+            cr_titles = cr_message.get('title', [])
+            cr_title = cr_titles[0] if cr_titles else ''
+
+            verbose_logs.append("  Comparing titles:")
+            verbose_logs.append(f"    BibTeX:   {bibtex_title}")
+            verbose_logs.append(f"    CrossRef: {cr_title}")
+
+            title_match = None
+            if bibtex_title and cr_title:
+                similarity = SequenceMatcher(
+                    None, bibtex_title.lower(), cr_title.lower()
+                ).ratio()
+                verbose_logs.append(
+                    f"    Similarity: {similarity:.2%}, Threshold: {self.TITLE_MATCH_THRESHOLD:.2%}"
+                )
+                title_match = similarity >= self.TITLE_MATCH_THRESHOLD
+                verbose_logs.append(f"    Result: {'✓ Match' if title_match else '✗ Mismatch'}")
+
+            mismatches = []
+            if title_match is False:
+                mismatches.append(('title', bibtex_title, cr_title))
+
+            # --- Year comparison ---
+            bibtex_year = self._remove_curly_braces(entry.get('year', '')).strip()
+            if bibtex_year:
+                cr_year = None
+                for date_field in ('published', 'published-print', 'issued'):
+                    date_parts = cr_message.get(date_field, {}).get('date-parts', [])
+                    if date_parts and date_parts[0]:
+                        cr_year = str(date_parts[0][0])
+                        break
+                if cr_year:
+                    if bibtex_year != cr_year:
+                        verbose_logs.append(
+                            f"  Year mismatch: BibTeX={bibtex_year}, CrossRef={cr_year}"
+                        )
+                        mismatches.append(('year', bibtex_year, cr_year))
+                    else:
+                        verbose_logs.append(f"  Year: {bibtex_year} ✓")
+
+            # --- Volume comparison ---
+            bibtex_volume = self._remove_curly_braces(entry.get('volume', '')).strip()
+            if bibtex_volume:
+                cr_volume = cr_message.get('volume', '')
+                if cr_volume:
+                    if bibtex_volume != cr_volume:
+                        verbose_logs.append(
+                            f"  Volume mismatch: BibTeX={bibtex_volume}, CrossRef={cr_volume}"
+                        )
+                        mismatches.append(('volume', bibtex_volume, cr_volume))
+                    else:
+                        verbose_logs.append(f"  Volume: {bibtex_volume} ✓")
+
+            # --- Journal / booktitle comparison ---
+            bibtex_journal = self._remove_curly_braces(
+                entry.get('journal', '') or entry.get('booktitle', '')
+            ).strip()
+            if bibtex_journal:
+                cr_containers = cr_message.get('container-title', [])
+                cr_journal = cr_containers[0] if cr_containers else ''
+                if cr_journal:
+                    journal_similarity = SequenceMatcher(
+                        None, bibtex_journal.lower(), cr_journal.lower()
+                    ).ratio()
+                    if journal_similarity < self.TITLE_MATCH_THRESHOLD:
+                        verbose_logs.append(
+                            f"  Journal mismatch: BibTeX='{bibtex_journal}', CrossRef='{cr_journal}'"
+                        )
+                        mismatches.append(('journal', bibtex_journal, cr_journal))
+                    else:
+                        verbose_logs.append(
+                            f"  Journal: ✓ (similarity {journal_similarity:.2%})"
+                        )
+
+            # --- Build result ---
+            if mismatches:
+                details = {
+                    'doi': doi,
+                    'entry_title': bibtex_title,
+                    'crossref_title': cr_title,
+                    'title_match': title_match,
+                    'mismatches': mismatches,
+                }
+                parts = [
+                    f"{field}: BibTeX='{bib}' vs CrossRef='{cr}'"
+                    for field, bib, cr in mismatches
+                ]
+                msg = "⚠ CrossRef DOI mismatch(es):\n    " + "\n    ".join(parts)
+                return False, msg, details, verbose_logs
+
+            if title_match is True:
+                return True, "✓ DOI verified via CrossRef", None, verbose_logs
+
+            # DOI resolved but no title available on one side to compare
+            return None, "- CrossRef: DOI resolved but title comparison skipped", None, verbose_logs
+
+        except requests.exceptions.RequestException as e:
+            verbose_logs.append(f"  ✗ Error querying CrossRef: {str(e)}")
+            return None, f"- Could not verify DOI via CrossRef: {str(e)}", None, verbose_logs
 
     def _check_version_info(self, entry: Dict) -> Optional[str]:
         """

--- a/verify_citations/verifier.py
+++ b/verify_citations/verifier.py
@@ -203,7 +203,35 @@ class CitationVerifier:
             verbose_logs.append("  ✗ No title found in entry")
             return False, None, verbose_logs
 
-        # Try arXiv first by ID if available (most reliable)
+        # Try CrossRef DOI resolution first (most reliable when DOI is present)
+        doi = self._remove_curly_braces(entry.get('doi', '')).strip()
+        if doi and re.search(r'10\.\d{4,}/', doi):
+            verbose_logs.append(f"  Trying CrossRef DOI resolution: {doi}")
+            try:
+                crossref_api_url = f"https://api.crossref.org/works/{quote_plus(doi)}"
+                if self.crossref_mailto:
+                    crossref_api_url += f"?mailto={self.crossref_mailto}"
+                response = self._make_request_with_retry('get', crossref_api_url, verbose_logs, timeout=self.timeout)
+                if response.status_code == 200:
+                    cr_message = response.json().get('message', {})
+                    cr_titles = cr_message.get('title', [])
+                    cr_title = cr_titles[0] if cr_titles else ''
+                    if cr_title:
+                        doi_url = f"https://doi.org/{doi}"
+                        verbose_logs.append(f"    ✓ DOI resolved via CrossRef: {doi_url}")
+                        return True, doi_url, verbose_logs
+                    else:
+                        verbose_logs.append("    ✗ DOI resolved but no title in CrossRef metadata")
+                elif response.status_code == 429:
+                    verbose_logs.append("    ✗ CrossRef rate limited (429) - trying alternative sources")
+                elif response.status_code == 404:
+                    verbose_logs.append("    ✗ DOI not found in CrossRef")
+                else:
+                    verbose_logs.append(f"    ✗ CrossRef returned status {response.status_code}")
+            except Exception as e:
+                verbose_logs.append(f"    ✗ Error resolving DOI via CrossRef: {str(e)}")
+
+        # Try arXiv by ID if available
         arxiv_id = entry.get('eprint', '') or self._extract_arxiv_id(entry.get('url', ''))
         if arxiv_id:
             verbose_logs.append(f"  Trying arXiv by ID: {arxiv_id}")
@@ -517,9 +545,108 @@ class CitationVerifier:
         verbose_logs = []
         
         try:
-            # Properly check if URL is from arxiv.org domain
             parsed_url = urlparse(search_url)
-            if parsed_url.netloc == 'arxiv.org' or parsed_url.netloc.endswith('.arxiv.org'):
+
+            # Check CrossRef/DOI metadata (when paper was found via DOI resolution)
+            if parsed_url.netloc == 'doi.org':
+                doi_from_url = parsed_url.path.lstrip('/')
+                api_url = f"https://api.crossref.org/works/{quote_plus(doi_from_url)}"
+                if self.crossref_mailto:
+                    api_url += f"?mailto={self.crossref_mailto}"
+
+                response = self._make_request_with_retry('get', api_url, verbose_logs, timeout=self.timeout)
+                if response.status_code == 200:
+                    cr_message = response.json().get('message', {})
+
+                    # Check title
+                    cr_titles = cr_message.get('title', [])
+                    online_title_original = cr_titles[0] if cr_titles else ''
+                    online_title = online_title_original.lower() if online_title_original else ''
+
+                    title_match = None
+                    if online_title:
+                        verbose_logs.append(f"  Comparing titles:")
+                        verbose_logs.append(f"    BibTeX: {self._remove_curly_braces(entry.get('title', ''))}")
+                        verbose_logs.append(f"    Online: {online_title_original}")
+
+                        title_similarity = self._calculate_title_similarity(title, online_title)
+                        title_match = title_similarity >= self.METADATA_SIMILARITY_THRESHOLD
+
+                        verbose_logs.append(f"    Similarity: {title_similarity:.2%}, Threshold: {self.METADATA_SIMILARITY_THRESHOLD:.2%}")
+                        verbose_logs.append(f"    Result: {'✓ Match' if title_match else '✗ Mismatch'}")
+
+                    # Check authors
+                    author_match = None
+                    online_authors_original = None
+                    cr_authors = cr_message.get('author', [])
+                    if cr_authors and entry_authors:
+                        author_display = []
+                        online_author_names = []
+                        for auth in cr_authors:
+                            given = auth.get('given', '')
+                            family = auth.get('family', '')
+                            name = auth.get('name', '')  # Institutional authors
+                            if family:
+                                author_display.append(f"{given} {family}".strip())
+                                online_author_names.append(family.lower())
+                            elif name:
+                                author_display.append(name)
+                                words = name.lower().split()
+                                if words:
+                                    online_author_names.append(words[-1])
+                        online_authors_original = ', '.join(author_display)
+
+                        verbose_logs.append(f"  Comparing authors:")
+                        verbose_logs.append(f"    BibTeX: {entry_authors}")
+                        verbose_logs.append(f"    Online: {online_authors_original}")
+
+                        entry_author_names = self._extract_author_names(entry_authors)
+
+                        verbose_logs.append(f"    Extracted BibTeX authors ({len(entry_author_names)}): {', '.join(entry_author_names)}")
+                        verbose_logs.append(f"    Extracted online authors ({len(online_author_names)}): {', '.join(online_author_names)}")
+
+                        has_et_al = 'and others' in entry_authors.lower() or 'et al' in entry_authors.lower()
+
+                        if entry_author_names and online_author_names:
+                            if has_et_al:
+                                verbose_logs.append(f"    Note: BibTeX has 'and others' - checking if listed authors are complete")
+                                if len(entry_author_names) > len(online_author_names):
+                                    author_similarity = 0.0
+                                    verbose_logs.append(f"    ✗ BibTeX has more authors than online ({len(entry_author_names)} > {len(online_author_names)})")
+                                else:
+                                    matching = sum(1 for name in entry_author_names if name in online_author_names)
+                                    verbose_logs.append(f"    Matching authors: {matching}/{len(entry_author_names)}")
+                                    if matching == len(entry_author_names):
+                                        coverage = len(entry_author_names) / len(online_author_names)
+                                        verbose_logs.append(f"    Coverage: {coverage:.2%} of total authors")
+                                        author_similarity = coverage
+                                    else:
+                                        author_similarity = 0.0
+                                        verbose_logs.append(f"    ✗ Not all listed authors found online")
+                            else:
+                                author_similarity = self._calculate_author_similarity(entry_author_names, online_author_names)
+                                verbose_logs.append(f"    Similarity: {author_similarity:.2%}, Threshold: 50%")
+
+                            author_match = author_similarity >= 0.5
+                            verbose_logs.append(f"    Result: {'✓ Match' if author_match else '✗ Mismatch'}")
+
+                    # Build details dictionary
+                    details = {
+                        'entry_title': self._remove_curly_braces(entry.get('title', '')),
+                        'online_title': online_title_original,
+                        'entry_authors': entry_authors,
+                        'online_authors': online_authors_original,
+                        'source_url': search_url,
+                        'title_match': title_match,
+                        'author_match': author_match
+                    }
+
+                    # Format and return result
+                    result, message = self._format_metadata_result(title_match, author_match, details)
+                    return result, message, (None if result else details), verbose_logs
+
+            # Check if URL is from arxiv.org domain
+            elif parsed_url.netloc == 'arxiv.org' or parsed_url.netloc.endswith('.arxiv.org'):
                 response = self._make_request_with_retry('get', search_url, verbose_logs, timeout=self.timeout)
                 if response.status_code == 200:
                     soup = BeautifulSoup(response.content, 'html.parser')

--- a/verify_citations/verifier.py
+++ b/verify_citations/verifier.py
@@ -1295,9 +1295,15 @@ class CitationVerifier:
         verbose_logs = []
         doi = self._remove_curly_braces(entry.get('doi', '')).strip()
 
+        # Detect bogus DOI values that should not be sent to CrossRef
+        bogus_patterns = {'mimeo', 'n/a', 'none', 'na', 'tbd', 'forthcoming', 'unpublished'}
+        if doi.lower() in bogus_patterns or not re.search(r'10\.\d{4,}/', doi):
+            verbose_logs.append(f"  ⚠ Bogus or malformed DOI value: '{doi}'")
+            return None, f"⚠ DOI value '{doi}' does not look like a valid DOI", None, verbose_logs
+
         verbose_logs.append(f"  Checking DOI via CrossRef: {doi}")
 
-        url = f"https://api.crossref.org/works/{doi}"
+        url = f"https://api.crossref.org/works/{quote_plus(doi)}"
         if self.crossref_mailto:
             url += f"?mailto={self.crossref_mailto}"
 


### PR DESCRIPTION
## Description

### Problem

`verify_citations` finds papers by title and verifies that title/author metadata match — but it never checks whether the **DOI itself points to the correct paper**. A BibTeX entry can pass all existing checks with flying colours while its DOI quietly resolves to a completely different publication.

This is surprisingly common. In my own 21-entry bibliography, 5 DOIs pointed to the wrong paper — all marked ✓ VERIFIED by the existing pipeline.

**Example:**

```bibtex
@article{Briani2007,
  title  = {{I}mplicit–{E}xplicit numerical schemes for jump–diffusion processes},
  author = {Briani, M. and Natalini, R. and Russo, G.},
  journal = {Calcolo},
  year   = {2007},
  doi    = {10.1007/s10092-007-0128-3},   % ← WRONG (correct: 10.1007/s10092-007-0128-x)
}
```

The paper exists and is findable by title. But the DOI `10.1007/s10092-007-0128-3` resolves to a different paper entirely. The existing checks cannot catch this.

### Solution

Add **Check 3b** that resolves each DOI via the [[CrossRef API](https://api.crossref.org/)](https://api.crossref.org) and compares the returned metadata against the BibTeX entry.

```
✗ DOI 10.1007/s10092-007-0128-3 resolves to "Some other paper on a different topic"
    (similarity 12%) — expected "Implicit–Explicit numerical schemes for jump–diffusion processes"
```

### Changes

Resolve each DOI via CrossRef API and compare returned metadata against BibTeX entry. Catches wrong DOIs invisible to title search.

- New `_check_doi_crossref()` method in `CitationVerifier`
- New `--crossref-mailto` CLI option for polite pool
- DOI summary in report output
- No new dependencies

**`verify_citations/verifier.py`**

- `__init__()`: new `crossref_mailto` parameter for the CrossRef polite pool (faster rate limits)
- `verify_citation()`: added `'doi_correct': None` to the checks dict + Check 3b block between Check 3 (metadata) and Check 4 (version info)
- New method `_check_doi_crossref()`: resolves DOI via `https://api.crossref.org/works/{doi}`, compares title using `SequenceMatcher` with the existing `TITLE_MATCH_THRESHOLD`, and also flags year/volume/journal mismatches

**`verify_citations/cli.py`**

- New `--crossref-mailto` CLI option
- Passes `crossref_mailto` to `CitationVerifier` constructor
- DOI verification summary section in `_print_summary()` output

### Design decisions

- Follows all existing library conventions: `_make_request_with_retry`, `_remove_curly_braces`, `SequenceMatcher`, `quote_plus`
- Returns the same `(bool|None, str, dict|None, list)` tuple pattern as `_check_metadata`
- **No new dependencies** — only uses `requests` (already required) and the CrossRef public API
- Bogus DOI values (`mimeo`, `N/A`, `none`) are detected and warned about rather than sent to CrossRef

### Usage

```bash
# Basic
verify-citations --bibtex-file references.bib

# With CrossRef polite pool (recommended — faster rate limits)
verify-citations --bibtex-file references.bib --crossref-mailto you@university.edu

# Verbose output shows CrossRef comparison details
verify-citations --bibtex-file references.bib --crossref-mailto you@university.edu --verbose
```

### Testing

All existing tests continue to pass. The new check runs automatically for any entry that has a DOI field.